### PR TITLE
Update basic-dependent-resources-keys.bicep

### DIFF
--- a/infra/modules-basic-keys/basic-dependent-resources-keys.bicep
+++ b/infra/modules-basic-keys/basic-dependent-resources-keys.bicep
@@ -38,7 +38,7 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
   properties: {
     customSubDomainName: toLower('${toLower(aiServicesName)}')
     apiProperties: {
-      statisticsEnabled: false
+
     }
     publicNetworkAccess: 'Enabled'
   }


### PR DESCRIPTION
error is thrown when this is part of the properties.  This is used for statistics of bing grounding so its possible its not working when we removed it

https://learn.microsoft.com/en-us/azure/templates/microsoft.cognitiveservices/accounts?pivots=deployment-language-bicep

statisticsEnabled | (Bing Search Only) The flag to enable statistics of Bing Search. | bool

